### PR TITLE
Fix CI test job: use --no-project to avoid rebuilding from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           uv venv
           uv pip install dist/*.whl pytest cryptography
-          uv run pytest tests/ -v
+          uv run --no-project pytest tests/ -v
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}


### PR DESCRIPTION
The test job downloads a pre-built wheel and installs it, but
`uv run pytest` detects the local pyproject.toml and tries to build
the project from source. This fails because libcdoc is only cloned
in the build job, not the test job.

Adding --no-project to `uv run` prevents it from trying to resolve
and build the local project, using only the already-installed wheel.

https://claude.ai/code/session_01KccqZFv6MqP2JVWabYn3mb