### PR TITLE
Add Python-specific SWIG wrapper with vector template instantiations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,20 +47,24 @@ macro(find_package)
     _find_package(${ARGV})
 endmacro()
 
-# Set up SWIG for Python - use libcdoc as module name (matches SWIG %module directive)
+# Set up SWIG for Python using our custom wrapper that adds Python-specific
+# template instantiations (ByteVector, StringVector, etc.) and director support
+set(PYCDOC_SWIG_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/swig/pycdoc.i)
 set(CMAKE_SWIG_FLAGS "")
-set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/libcdoc/libcdoc.i PROPERTY CPLUSPLUS ON)
-set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/libcdoc/libcdoc.i PROPERTY SWIG_MODULE_NAME libcdoc)
-# Set SWIG include directories
-set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/libcdoc/libcdoc.i
-    PROPERTY INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/libcdoc/cdoc)
+set_property(SOURCE ${PYCDOC_SWIG_SOURCE} PROPERTY CPLUSPLUS ON)
+set_property(SOURCE ${PYCDOC_SWIG_SOURCE} PROPERTY SWIG_MODULE_NAME libcdoc)
+# Set SWIG include directories - need both libcdoc/ (for libcdoc.i) and libcdoc/cdoc/ (for headers)
+set_property(SOURCE ${PYCDOC_SWIG_SOURCE}
+    PROPERTY INCLUDE_DIRECTORIES
+    ${CMAKE_CURRENT_SOURCE_DIR}/libcdoc
+    ${CMAKE_CURRENT_SOURCE_DIR}/libcdoc/cdoc)
 
 # Create the Python extension
 swig_add_library(pycdoc_swig
     TYPE MODULE
     LANGUAGE python
     OUTPUT_DIR ${CMAKE_BINARY_DIR}/pycdoc
-    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/libcdoc/libcdoc.i
+    SOURCES ${PYCDOC_SWIG_SOURCE}
 )
 
 # Include directories for C++ compilation
@@ -74,7 +78,7 @@ set_target_properties(pycdoc_swig PROPERTIES
     OUTPUT_NAME "_libcdoc"
     PREFIX ""
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pycdoc
-    SWIG_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/libcdoc/cdoc
+    SWIG_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/libcdoc;${CMAKE_CURRENT_SOURCE_DIR}/libcdoc/cdoc"
 )
 
 # Link against cdoc and Python

--- a/swig/pycdoc.i
+++ b/swig/pycdoc.i
@@ -1,0 +1,22 @@
+/*
+ * pycdoc - Python-specific SWIG interface for libcdoc
+ *
+ * This wraps the upstream libcdoc.i and adds Python-specific
+ * template instantiations and director support.
+ */
+
+/* Enable directors for Python subclassing of C++ classes */
+%feature("director") libcdoc::DataSource;
+%feature("director") libcdoc::CryptoBackend;
+%feature("director") libcdoc::PKCS11Backend;
+%feature("director") libcdoc::NetworkBackend;
+%feature("director") libcdoc::Configuration;
+%feature("director") libcdoc::ILogger;
+
+/* Include the upstream libcdoc SWIG interface */
+%include "libcdoc.i"
+
+/* Python-specific std::vector template instantiations */
+%template(ByteVector) std::vector<uint8_t>;
+%template(ByteVectorVector) std::vector<std::vector<uint8_t>>;
+%template(StringVector) std::vector<std::string>;


### PR DESCRIPTION
The upstream libcdoc.i only defines %template(LockVector) for std::vector<libcdoc::Lock>. The ByteVector, ByteVectorVector, and StringVector types used by pycdoc's __init__.py have no corresponding %template directives — the upstream handles these via Java-specific typemaps (#ifdef SWIGJAVA) which don't apply to Python.

This creates swig/pycdoc.i, a thin wrapper that:
- Includes the upstream libcdoc.i
- Adds %template(ByteVector) for std::vector<uint8_t>
- Adds %template(ByteVectorVector) for std::vector<std::vector<uint8_t>>
- Adds %template(StringVector) for std::vector<std::string>
- Enables %feature("director") for Python subclassing of C++ classes

CMakeLists.txt is updated to use our wrapper as the SWIG source, with include paths pointing to both libcdoc/ (for libcdoc.i) and libcdoc/cdoc/ (for the C++ headers).

https://claude.ai/code/session_01KccqZFv6MqP2JVWabYn3mb