### PR TITLE
Add SWIG %rename for automatic camelCase to snake_case API

### DIFF
--- a/examples/create_cdoc.py
+++ b/examples/create_cdoc.py
@@ -46,23 +46,23 @@ def main():
 
     # Create the CDOC writer
     print(f"\nCreating CDOC file: {output_file}")
-    writer = pycdoc.CDocWriter.createWriter(2, output_file, None, None, None)
+    writer = pycdoc.CDocWriter.create_writer(2, output_file, None, None, None)
     if writer is None:
         print("ERROR: Failed to create writer")
         return 1
 
     # Add recipient (the certificate holder can decrypt)
-    recipient = pycdoc.Recipient.makeCertificate("Test User", cert_der)
-    result = writer.addRecipient(recipient)
+    recipient = pycdoc.Recipient.make_certificate("Test User", cert_der)
+    result = writer.add_recipient(recipient)
     if result != pycdoc.OK:
-        print(f"ERROR: addRecipient failed: {result}")
+        print(f"ERROR: add_recipient failed: {result}")
         return 1
     print("  Added recipient: Test User")
 
     # Begin encryption
-    result = writer.beginEncryption()
+    result = writer.begin_encryption()
     if result != pycdoc.OK:
-        print(f"ERROR: beginEncryption failed: {result}")
+        print(f"ERROR: begin_encryption failed: {result}")
         return 1
 
     # Add files to the container
@@ -72,22 +72,22 @@ def main():
     ]
 
     for filename, content in files:
-        result = writer.addFile(filename, len(content))
+        result = writer.add_file(filename, len(content))
         if result != pycdoc.OK:
-            print(f"ERROR: addFile failed for {filename}: {result}")
+            print(f"ERROR: add_file failed for {filename}: {result}")
             return 1
 
-        result = writer.writeData(content)
+        result = writer.write_data(content)
         if result != pycdoc.OK:
-            print(f"ERROR: writeData failed for {filename}: {result}")
+            print(f"ERROR: write_data failed for {filename}: {result}")
             return 1
 
         print(f"  Added file: {filename} ({len(content)} bytes)")
 
     # Finish encryption
-    result = writer.finishEncryption()
+    result = writer.finish_encryption()
     if result != pycdoc.OK:
-        print(f"ERROR: finishEncryption failed: {result}")
+        print(f"ERROR: finish_encryption failed: {result}")
         return 1
 
     # Clean up writer
@@ -99,14 +99,14 @@ def main():
 
     # Read back the CDOC to verify
     print("\nReading CDOC file...")
-    reader = pycdoc.CDocReader.createReader(output_file, None, None, None)
+    reader = pycdoc.CDocReader.create_reader(output_file, None, None, None)
     if reader is None:
         print("ERROR: Failed to create reader")
         return 1
 
     print(f"  CDOC version: {reader.version}")
 
-    locks = reader.getLocks()
+    locks = reader.get_locks()
     print(f"  Recipients: {len(locks)}")
     for i, lock in enumerate(locks):
         print(f"    [{i}] {lock.label}")

--- a/examples/create_cdoc_for_id.py
+++ b/examples/create_cdoc_for_id.py
@@ -96,32 +96,32 @@ def fetch_certificate_from_ldap(personal_id: str) -> tuple[bytes, str]:
 def create_cdoc(cert_der: bytes, cn: str, output_file: str, files: list[tuple[str, bytes]]):
     """Create a CDOC 2.0 file."""
     print(f"\nCreating CDOC file: {output_file}")
-    writer = pycdoc.CDocWriter.createWriter(2, output_file, None, None, None)
+    writer = pycdoc.CDocWriter.create_writer(2, output_file, None, None, None)
     if writer is None:
         raise RuntimeError("Failed to create writer")
 
-    recipient = pycdoc.Recipient.makeCertificate(cn, cert_der)
-    result = writer.addRecipient(recipient)
+    recipient = pycdoc.Recipient.make_certificate(cn, cert_der)
+    result = writer.add_recipient(recipient)
     if result != pycdoc.OK:
-        raise RuntimeError(f"addRecipient failed: {result}")
+        raise RuntimeError(f"add_recipient failed: {result}")
     print(f"  Recipient: {cn}")
 
-    result = writer.beginEncryption()
+    result = writer.begin_encryption()
     if result != pycdoc.OK:
-        raise RuntimeError(f"beginEncryption failed: {result}")
+        raise RuntimeError(f"begin_encryption failed: {result}")
 
     for filename, content in files:
-        result = writer.addFile(filename, len(content))
+        result = writer.add_file(filename, len(content))
         if result != pycdoc.OK:
-            raise RuntimeError(f"addFile failed for {filename}: {result}")
-        result = writer.writeData(content)
+            raise RuntimeError(f"add_file failed for {filename}: {result}")
+        result = writer.write_data(content)
         if result != pycdoc.OK:
-            raise RuntimeError(f"writeData failed for {filename}: {result}")
+            raise RuntimeError(f"write_data failed for {filename}: {result}")
         print(f"  Added: {filename} ({len(content)} bytes)")
 
-    result = writer.finishEncryption()
+    result = writer.finish_encryption()
     if result != pycdoc.OK:
-        raise RuntimeError(f"finishEncryption failed: {result}")
+        raise RuntimeError(f"finish_encryption failed: {result}")
 
     del writer
     return os.path.getsize(output_file)
@@ -164,9 +164,9 @@ def main():
     print(f"\nCreated: {args.output} ({size} bytes)")
 
     # Verify
-    reader = pycdoc.CDocReader.createReader(args.output, None, None, None)
+    reader = pycdoc.CDocReader.create_reader(args.output, None, None, None)
     if reader:
-        print(f"\nVerified: CDOC {reader.version} with {len(reader.getLocks())} recipient(s)")
+        print(f"\nVerified: CDOC {reader.version} with {len(reader.get_locks())} recipient(s)")
         del reader
 
     print("\nDecrypt with: DigiDoc4 Client or cdoc-tool decrypt")

--- a/src/pycdoc/__init__.py
+++ b/src/pycdoc/__init__.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 
 from pycdoc.libcdoc import (
     # Version and utilities
-    getVersion as get_version,
-    getErrorStr as get_error_str,
+    get_version,
+    get_error_str,
 
     # Result codes
     OK,
@@ -182,18 +182,18 @@ def encrypt(
 
     try:
         # Create CDOC 2.0 writer
-        writer = CDocWriter.createWriter(2, output_path, None, None, None)
+        writer = CDocWriter.create_writer(2, output_path, None, None, None)
         if writer is None:
             raise RuntimeError("Failed to create CDOC writer")
 
         # Add recipient
-        recipient = Recipient.makeCertificate(cn, cert_der)
-        result = writer.addRecipient(recipient)
+        recipient = Recipient.make_certificate(cn, cert_der)
+        result = writer.add_recipient(recipient)
         if result != OK:
             raise RuntimeError(f"Failed to add recipient: {get_error_str(result)}")
 
         # Begin encryption
-        result = writer.beginEncryption()
+        result = writer.begin_encryption()
         if result != OK:
             raise RuntimeError(f"Failed to begin encryption: {get_error_str(result)}")
 
@@ -222,15 +222,15 @@ def encrypt(
 
         # Write files
         for name, content in files_to_write:
-            result = writer.addFile(name, len(content))
+            result = writer.add_file(name, len(content))
             if result != OK:
                 raise RuntimeError(f"Failed to add file {name}: {get_error_str(result)}")
-            result = writer.writeData(content)
+            result = writer.write_data(content)
             if result != OK:
                 raise RuntimeError(f"Failed to write data for {name}: {get_error_str(result)}")
 
         # Finish encryption
-        result = writer.finishEncryption()
+        result = writer.finish_encryption()
         if result != OK:
             raise RuntimeError(f"Failed to finish encryption: {get_error_str(result)}")
 

--- a/swig/pycdoc.i
+++ b/swig/pycdoc.i
@@ -5,13 +5,18 @@
  * template instantiations and director support.
  */
 
+/* Global camelCase → snake_case renaming for all functions and methods.
+   Must appear BEFORE %include of upstream interface. */
+%rename("%(undercase)s", %$isfunction, %$not %$isconstructor, %$not %$isdestructor) "";
+%rename("%(undercase)s", %$ismember, %$not %$isenumitem, %$not %$isconstant, %$not %$isconstructor, %$not %$isdestructor, %$not %$isenum) "";
+
 /* Enable directors for Python subclassing of C++ classes */
 %feature("director") libcdoc::DataSource;
 %feature("director") libcdoc::CryptoBackend;
 %feature("director") libcdoc::PKCS11Backend;
 %feature("director") libcdoc::NetworkBackend;
 %feature("director") libcdoc::Configuration;
-%feature("director") libcdoc::ILogger;
+%feature("director") libcdoc::Logger;
 
 /* Include the upstream libcdoc SWIG interface */
 %include "libcdoc.i"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -164,7 +164,7 @@ class TestRecipient:
     def test_recipient_is_empty(self):
         from pycdoc import Recipient
         r = Recipient()
-        assert r.isEmpty()
+        assert r.is_empty()
 
     def test_recipient_label(self):
         from pycdoc import Recipient

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -55,29 +55,29 @@ class TestCDocCreation:
 
         try:
             # Create writer
-            writer = pycdoc.CDocWriter.createWriter(2, cdoc_path, None, None, None)
+            writer = pycdoc.CDocWriter.create_writer(2, cdoc_path, None, None, None)
             assert writer is not None
 
             # Add recipient
-            recipient = pycdoc.Recipient.makeCertificate("Test User", cert_der)
-            assert recipient.isCertificate()
-            result = writer.addRecipient(recipient)
+            recipient = pycdoc.Recipient.make_certificate("Test User", cert_der)
+            assert recipient.is_certificate()
+            result = writer.add_recipient(recipient)
             assert result == pycdoc.OK
 
             # Begin encryption
-            result = writer.beginEncryption()
+            result = writer.begin_encryption()
             assert result == pycdoc.OK
 
             # Add a file
             content = b"Hello, World! This is a secret message."
-            result = writer.addFile("test.txt", len(content))
+            result = writer.add_file("test.txt", len(content))
             assert result == pycdoc.OK
 
-            result = writer.writeData(content)
+            result = writer.write_data(content)
             assert result == pycdoc.OK
 
             # Finish
-            result = writer.finishEncryption()
+            result = writer.finish_encryption()
             assert result == pycdoc.OK
             del writer
 
@@ -99,10 +99,10 @@ class TestCDocCreation:
             cdoc_path = f.name
 
         try:
-            writer = pycdoc.CDocWriter.createWriter(2, cdoc_path, None, None, None)
-            recipient = pycdoc.Recipient.makeCertificate("Test User", cert_der)
-            writer.addRecipient(recipient)
-            writer.beginEncryption()
+            writer = pycdoc.CDocWriter.create_writer(2, cdoc_path, None, None, None)
+            recipient = pycdoc.Recipient.make_certificate("Test User", cert_der)
+            writer.add_recipient(recipient)
+            writer.begin_encryption()
 
             # Add multiple files
             files = [
@@ -112,12 +112,12 @@ class TestCDocCreation:
             ]
 
             for name, content in files:
-                result = writer.addFile(name, len(content))
+                result = writer.add_file(name, len(content))
                 assert result == pycdoc.OK
-                result = writer.writeData(content)
+                result = writer.write_data(content)
                 assert result == pycdoc.OK
 
-            writer.finishEncryption()
+            writer.finish_encryption()
             del writer
 
             assert os.path.getsize(cdoc_path) > 0
@@ -141,22 +141,22 @@ class TestCDocReading:
 
         try:
             # Create a CDOC file first
-            writer = pycdoc.CDocWriter.createWriter(2, cdoc_path, None, None, None)
-            recipient = pycdoc.Recipient.makeCertificate("Test Recipient", cert_der)
-            writer.addRecipient(recipient)
-            writer.beginEncryption()
-            writer.addFile("test.txt", 5)
-            writer.writeData(b"hello")
-            writer.finishEncryption()
+            writer = pycdoc.CDocWriter.create_writer(2, cdoc_path, None, None, None)
+            recipient = pycdoc.Recipient.make_certificate("Test Recipient", cert_der)
+            writer.add_recipient(recipient)
+            writer.begin_encryption()
+            writer.add_file("test.txt", 5)
+            writer.write_data(b"hello")
+            writer.finish_encryption()
             del writer
 
             # Read it back
-            reader = pycdoc.CDocReader.createReader(cdoc_path, None, None, None)
+            reader = pycdoc.CDocReader.create_reader(cdoc_path, None, None, None)
             assert reader is not None
             assert reader.version == 2
 
             # Get locks
-            locks = reader.getLocks()
+            locks = reader.get_locks()
             assert len(locks) == 1
 
             del reader
@@ -176,17 +176,17 @@ class TestCDocReading:
 
         try:
             # Create a CDOC 2 file
-            writer = pycdoc.CDocWriter.createWriter(2, cdoc_path, None, None, None)
-            recipient = pycdoc.Recipient.makeCertificate("Test", cert_der)
-            writer.addRecipient(recipient)
-            writer.beginEncryption()
-            writer.addFile("test.txt", 4)
-            writer.writeData(b"test")
-            writer.finishEncryption()
+            writer = pycdoc.CDocWriter.create_writer(2, cdoc_path, None, None, None)
+            recipient = pycdoc.Recipient.make_certificate("Test", cert_der)
+            writer.add_recipient(recipient)
+            writer.begin_encryption()
+            writer.add_file("test.txt", 4)
+            writer.write_data(b"test")
+            writer.finish_encryption()
             del writer
 
             # Check version detection
-            version = pycdoc.CDocReader.getCDocFileVersion(cdoc_path)
+            version = pycdoc.CDocReader.get_cdoc_file_version(cdoc_path)
             assert version == 2
 
         finally:


### PR DESCRIPTION
## Summary

- Add SWIG `%(undercase)s` rename directives to automatically convert all C++ camelCase method names to Python snake_case (e.g. `createWriter` → `create_writer`, `addRecipient` → `add_recipient`)
- Exclude constructors, destructors, enum items, constants, and enum type declarations from renaming to avoid naming collisions (e.g. `Recipient::Type` vs `Recipient::type`)
- Update all call sites in tests, examples, and `__init__.py` to use the new snake_case names

## Breaking changes

All public API methods are now snake_case. Users must update their code:

| Before | After |
|--------|-------|
| `CDocWriter.createWriter()` | `CDocWriter.create_writer()` |
| `Recipient.makeCertificate()` | `Recipient.make_certificate()` |
| `writer.addRecipient()` | `writer.add_recipient()` |
| `writer.beginEncryption()` | `writer.begin_encryption()` |
| `writer.addFile()` | `writer.add_file()` |
| `writer.writeData()` | `writer.write_data()` |
| `writer.finishEncryption()` | `writer.finish_encryption()` |
| `reader.getLocks()` | `reader.get_locks()` |
| `recipient.isEmpty()` | `recipient.is_empty()` |
| `recipient.isCertificate()` | `recipient.is_certificate()` |

## Test plan

- [x] All 45 tests pass (3 skipped for pre-existing int64_t issues)
- [x] Constructors work correctly (`Recipient()`, `DataBuffer()`, `CertificateList()`, etc.)
- [x] Enum constants preserved (`OK`, `SYMMETRIC_KEY`, `Type`, etc.)
- [x] Integration tests verify full encrypt/decrypt workflow with snake_case API

🤖 Generated with [Claude Code](https://claude.com/claude-code)